### PR TITLE
chore: register spring-boot-demo-api in Backstage catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: spring-boot-demo-api
+  description: Sample Spring Boot API in Java
+  annotations:
+    github.com/project-slug: github.com?owner=middlewaregruppen&repo=spring-boot-demo-api&organization=middlewaregruppen
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: service
+  lifecycle: experimental
+  owner: group:default/the_people

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# spring-boot-demo-api
+
+Sample Spring Boot API in Java
+
+## Overview
+
+> This documentation was scaffolded automatically by the Backstage
+> **Register a Component** template. Replace this placeholder content
+> with real documentation for your component.
+
+## Getting Started
+
+Describe how to run, build, and test this component locally.
+
+## Architecture
+
+Describe the main architectural decisions and component boundaries.
+
+## Operations
+
+Describe deployment, monitoring, and on-call runbooks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: spring-boot-demo-api
+site_description: Sample Spring Boot API in Java
+docs_dir: docs
+
+nav:
+  - Home: index.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Register component in Backstage

This PR was opened automatically by the **Register a Component** template
in Backstage.

### What's included

- `catalog-info.yaml` — registers this repo as a **service**
  component owned by `group:default/the_people`.

- `mkdocs.yml` + `docs/index.md` — minimal TechDocs scaffold. The Docs tab
  in Backstage will be populated once this PR is merged and CI publishes the docs.


### Next steps (after merging)

1. Merge this PR.
2. Backstage picks up the new `catalog-info.yaml` within 30 minutes
   (or immediately if you trigger a manual catalog refresh).

3. Add the TechDocs publish workflow to `.github/workflows/techdocs.yml`
   (copy from `golden-paths-base-images`) so docs are built on every push.

